### PR TITLE
Switch order of the data source/owner tuple

### DIFF
--- a/lib/rrd_json.ml
+++ b/lib/rrd_json.ml
@@ -44,9 +44,9 @@ let json_of_ds ?(owner=Rrd.Host) ?(rshift=4) ds buf =
 		(* end; *)
 	end
 
-let json_of_dss ?hdr timestamp (dss : (Ds.ds * Rrd.ds_owner) list) =
+let json_of_dss ?hdr timestamp (dss : (Rrd.ds_owner * Ds.ds) list) =
 	let buf = Buffer.create 100 in
-	List.iter (fun (ds, owner) -> json_of_ds ~owner ds buf) dss;
+	List.iter (fun (owner, ds) -> json_of_ds ~owner ds buf) dss;
 	let dss = Buffer.contents buf in
 	let payload = 
 		Printf.sprintf "{\n  \"timestamp\": %Ld,\n  \"datasources\": {\n%s\n  }\n}" timestamp
@@ -90,13 +90,13 @@ let json_metadata_of_ds ?(owner=Rrd.Host) ds buf =
 
 (** Return a string containing the JSON metadata of a list of (ds * ds_owner)
   * tuples [dss]. The string will not contain the values of the datasources. *)
-let json_metadata_of_dss (dss : (Ds.ds * Rrd.ds_owner) list) =
+let json_metadata_of_dss (dss : (Rrd.ds_owner * Ds.ds) list) =
 	let buf = Buffer.create 100 in
 	Buffer.add_string buf "{\"datasources\":{";
 	let rec add_dss = function
 		| [] -> ()
-		| (ds, owner) :: [] -> json_metadata_of_ds ~owner ds buf
-		| (ds, owner) :: rest ->
+		| (owner, ds) :: [] -> json_metadata_of_ds ~owner ds buf
+		| (owner, ds) :: rest ->
 			json_metadata_of_ds ~owner ds buf;
 			Buffer.add_char buf ',';
 			add_dss rest

--- a/lib/rrd_json.mli
+++ b/lib/rrd_json.mli
@@ -15,8 +15,8 @@
 val json_of_ds: ?owner:Rrd.ds_owner ->
 	?rshift:int -> Ds.ds -> Buffer.t -> unit
 
-val json_of_dss: ?hdr:string -> int64 -> (Ds.ds * Rrd.ds_owner) list -> string
+val json_of_dss: ?hdr:string -> int64 -> (Rrd.ds_owner * Ds.ds) list -> string
 
 val json_metadata_of_ds: ?owner:Rrd.ds_owner -> Ds.ds -> Buffer.t -> unit
 
-val json_metadata_of_dss: (Ds.ds * Rrd.ds_owner) list -> string
+val json_metadata_of_dss: (Rrd.ds_owner * Ds.ds) list -> string

--- a/lib/rrd_protocol.ml
+++ b/lib/rrd_protocol.ml
@@ -22,7 +22,7 @@ exception Read_error
 
 type payload = {
 	timestamp: int64;
-	datasources : (Ds.ds * Rrd.ds_owner) list;
+	datasources : (Rrd.ds_owner * Ds.ds) list;
 }
 
 type protocol = {

--- a/lib/rrd_protocol.mli
+++ b/lib/rrd_protocol.mli
@@ -22,7 +22,7 @@ exception Read_error
 
 type payload = {
 	timestamp: int64;
-	datasources : (Ds.ds * Rrd.ds_owner) list;
+	datasources : (Rrd.ds_owner * Ds.ds) list;
 }
 
 type protocol = {

--- a/lib/rrd_protocol_v1.ml
+++ b/lib/rrd_protocol_v1.ml
@@ -40,7 +40,7 @@ let ds_value_of_rpc ~(ty : value_type) ~(rpc : Rpc.t) : Rrd.ds_value_type =
 
 (* A function that converts a JSON type into a datasource type, assigning
  * default values appropriately. *)
-let ds_of_rpc ((name, rpc) : (string * Rpc.t)) : (Ds.ds * Rrd.ds_owner) =
+let ds_of_rpc ((name, rpc) : (string * Rpc.t)) : (Rrd.ds_owner * Ds.ds) =
 	try
 		let open Rpc in
 		let kvs = Rrd_rpc.dict_of_rpc ~rpc in
@@ -68,7 +68,7 @@ let ds_of_rpc ((name, rpc) : (string * Rpc.t)) : (Ds.ds * Rrd.ds_owner) =
 		in
 		let ds = Ds.ds_make ~name ~description ~units ~ty ~value ~min ~max
 			~default:true () in
-		ds, owner
+		owner, ds
 	with e -> raise e
 
 (* A function that parses the payload written by a plugin into the payload

--- a/test/reader_commands.ml
+++ b/test/reader_commands.ml
@@ -14,7 +14,7 @@
 
 open Rrd_protocol
 
-let string_of_data_source ds owner =
+let string_of_data_source owner ds =
 	let owner_string = match owner with
 	| Rrd.Host -> "Host"
 	| Rrd.SR sr -> "SR " ^ sr
@@ -39,8 +39,8 @@ let interpret_payload payload =
 	Printf.printf "timestamp = %Ld\n%!" payload.timestamp;
 	print_endline "---------- Data sources ----------";
 	List.iter
-		(fun (ds, owner) ->
-			print_endline (string_of_data_source ds owner);
+		(fun (owner, ds) ->
+			print_endline (string_of_data_source owner ds);
 			print_endline "----------")
 		payload.datasources
 

--- a/test/writer_commands.ml
+++ b/test/writer_commands.ml
@@ -28,22 +28,25 @@ let get_extra_data_sources_flag =
 
 let generate_time_data_source () =
 	let current_time = now () in
+	Rrd.Host,
 	Ds.ds_make ~name:"current_time"
 		~description:"The current time"
 		~value:(Rrd.VT_Int64 current_time) ~ty:(Rrd.Gauge)
-		~default:true ~units:"seconds" (), Rrd.Host
+		~default:true ~units:"seconds" ()
 
 let generate_random_int_data_source () =
+	Rrd.SR "my_sr",
 	Ds.ds_make ~name:"random_int"
 		~description:"A random integer"
 		~value:(Rrd.VT_Int64 (Random.int64 256L)) ~ty:(Rrd.Absolute)
-		~default:true ~units:"things" (), Rrd.SR "my_sr"
+		~default:true ~units:"things" ()
 
 let generate_random_float_data_source () =
+	Rrd.VM "my_vm",
 	Ds.ds_make ~name:"random_float"
 		~description:"A random float"
 		~value:(Rrd.VT_Float (Random.float 1.0)) ~ty:(Rrd.Absolute)
-		~default:true ~units:"bits of things" (), Rrd.VM "my_vm"
+		~default:true ~units:"bits of things" ()
 
 let generate_data_sources () =
 	let include_extra_data_sources = get_extra_data_sources_flag () in


### PR DESCRIPTION
This matches the order used across the rest of the RRD daemon codebase.
