### PR TITLE
CA-181659: Include ds_default field in the protocol

### DIFF
--- a/lib/rrd_json.ml
+++ b/lib/rrd_json.ml
@@ -66,7 +66,8 @@ let json_metadata_of_ds ?(owner=Rrd.Host) ds buf =
 	let open Ds in
 	let add_string str = Buffer.add_string buf str in
 	let json_line_string ?(last=false) n v = add_string (Printf.sprintf "\"%s\":\"%s\"%s" n v (if last then "" else ","))
-	and json_line_float  ?(last=false) n v = add_string (Printf.sprintf "\"%s\":\"%.2f\"%s" n v (if last then "" else ",")) in
+	and json_line_float  ?(last=false) n v = add_string (Printf.sprintf "\"%s\":\"%.2f\"%s" n v (if last then "" else ","))
+	and json_line_bool  ?(last=false) n v = add_string (Printf.sprintf "\"%s\":\"%b\"%s" n v (if last then "" else ",")) in
 	begin
 		add_string (Printf.sprintf "\"%s\":{" ds.ds_name);
 		if ds.ds_description != "" then (json_line_string "description" ds.ds_description);
@@ -82,6 +83,7 @@ let json_metadata_of_ds ?(owner=Rrd.Host) ds buf =
 			| Rrd.Gauge -> "absolute"
 			| Rrd.Absolute -> "rate"
 			| Rrd.Derive -> "absolute_to_rate");
+		json_line_bool "default" ds.ds_default;
 		json_line_string "units" ds.ds_units;
 		json_line_float "min" ds.ds_min;
 		json_line_float ~last:true "max" ds.ds_max;

--- a/lib/rrd_protocol_v2.ml
+++ b/lib/rrd_protocol_v2.ml
@@ -181,10 +181,13 @@ let uninitialised_ds_of_rpc ((name, rpc) : (string * Rpc.t))
 		float_of_string (Rrd_rpc.assoc_opt ~key:"max" ~default:"infinity" kvs) in
 	let owner =
 		Rrd_rpc.owner_of_string
-			(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs)
-	in
+			(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs) in
+	let default =
+		bool_of_string
+			(Rrd_rpc.assoc_opt ~key:"default"
+				~default:(string_of_bool !Rrd_protocol.ds_default) kvs) in
 	let ds = Ds.ds_make ~name ~description ~units
-		~ty ~value ~min ~max ~default:!Rrd_protocol.ds_default () in
+		~ty ~value ~min ~max ~default () in
 	owner, ds
 
 let parse_metadata metadata =


### PR DESCRIPTION
As this was not transmitted it was unilaterally interpreted as false and so
users of the rrd-transport library will not have their ds_default field
honoured if set to true. This means that (would-be) default datasources will
not display unless the override to display all non-default datasources is set.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>