### PR TITLE
Support the `default` field in the V1 protocol

### DIFF
--- a/lib/rrd_json.ml
+++ b/lib/rrd_json.ml
@@ -19,7 +19,8 @@ let json_of_ds ?(owner=Rrd.Host) ?(rshift=4) ds buf =
 		Buffer.add_string buf str in
 	let json_line_string ?(last=false) n v = add_string (Printf.sprintf "  \"%s\": \"%s\"%s\n" n v (if last then "" else ","))
 	and json_line_int64  ?(last=false) n v = add_string (Printf.sprintf "  \"%s\": \"%Ld\"%s\n" n v (if last then "" else ","))
-	and json_line_float ?(last=false) n v  = add_string (Printf.sprintf "  \"%s\": \"%.2f\"%s\n" n v (if last then "" else ",")) in
+	and json_line_float ?(last=false) n v  = add_string (Printf.sprintf "  \"%s\": \"%.2f\"%s\n" n v (if last then "" else ","))
+	and json_line_bool  ?(last=false) n v = add_string (Printf.sprintf "\"%s\":\"%b\"%s" n v (if last then "" else ",")) in
 	begin
 		add_string (Printf.sprintf "\"%s\": {\n" ds.ds_name);
 		if ds.ds_description != "" then (json_line_string "description" ds.ds_description);
@@ -32,6 +33,7 @@ let json_of_ds ?(owner=Rrd.Host) ?(rshift=4) ds buf =
 			| Rrd.Gauge -> "absolute"
 			| Rrd.Absolute -> "rate"
 			| Rrd.Derive -> "absolute_to_rate");
+		json_line_bool "default" ds.ds_default;
 		json_line_string "units" ds.ds_units;
 		json_line_float "min" ds.ds_min;
 		json_line_float ~last:true "max" ds.ds_max;

--- a/lib/rrd_protocol_v1.ml
+++ b/lib/rrd_protocol_v1.ml
@@ -68,8 +68,12 @@ let ds_of_rpc ((name, rpc) : (string * Rpc.t)) : (Rrd.ds_owner * Ds.ds) =
 			Rrd_rpc.owner_of_string
 				(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs)
 		in
+		let default =
+			bool_of_string
+				(Rrd_rpc.assoc_opt ~key:"default"
+					~default:(string_of_bool !Rrd_protocol.ds_default) kvs) in
 		let ds = Ds.ds_make ~name ~description ~units ~ty ~value ~min ~max
-			~default:!Rrd_protocol.ds_default () in
+			~default () in
 		owner, ds
 	with e -> raise e
 

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -60,12 +60,13 @@ let make_random_datasource () =
 			else Rrd.Derive
 		end
 	in
+	let default = Random.bool () in
 	owner,
 	Ds.ds_make ~name:"test_ds"
 		~description:"A datasource"
 		~value
 		~ty
-		~default:false
+		~default
 		~units:"things" ()
 
 let make_random_payload timestamp datasource_count =

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -15,7 +15,7 @@ let test_payload = Rrd_protocol.({
 			~description:"A test integer"
 			~value:(Rrd.VT_Int64 5678L)
 			~ty:Rrd.Gauge
-			~default:false
+			~default:true
 			~units:"things" ();
 		Rrd.VM "test_vm",
 		Ds.ds_make ~name:"test_float1"


### PR DESCRIPTION
Now that both protocols support this field, we can vary it in the tests.