### PR TITLE
CA-182919: Remove ds_default global mutable

### DIFF
--- a/lib/rrd_protocol.ml
+++ b/lib/rrd_protocol.ml
@@ -20,8 +20,6 @@ exception No_update
 exception Payload_too_large
 exception Read_error
 
-let ds_default = ref false
-
 type payload = {
 	timestamp: int64;
 	datasources : (Rrd.ds_owner * Ds.ds) list;

--- a/lib/rrd_protocol.mli
+++ b/lib/rrd_protocol.mli
@@ -29,5 +29,3 @@ type protocol = {
 	make_payload_reader: unit -> (Cstruct.t -> payload);
 	make_payload_writer: unit -> ((int -> Cstruct.t) -> payload -> unit);
 }
-
-val ds_default: bool ref

--- a/lib/rrd_protocol_v1.ml
+++ b/lib/rrd_protocol_v1.ml
@@ -66,14 +66,11 @@ let ds_of_rpc ((name, rpc) : (string * Rpc.t)) : (Rrd.ds_owner * Ds.ds) =
 			float_of_string (Rrd_rpc.assoc_opt ~key:"max" ~default:"infinity" kvs) in
 		let owner =
 			Rrd_rpc.owner_of_string
-				(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs)
-		in
+				(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs) in
 		let default =
-			bool_of_string
-				(Rrd_rpc.assoc_opt ~key:"default"
-					~default:(string_of_bool !Rrd_protocol.ds_default) kvs) in
-		let ds = Ds.ds_make ~name ~description ~units ~ty ~value ~min ~max
-			~default () in
+			bool_of_string (Rrd_rpc.assoc_opt ~key:"default" ~default:"false" kvs) in
+		let ds =
+			Ds.ds_make ~name ~description ~units ~ty ~value ~min ~max ~default () in
 		owner, ds
 	with e -> raise e
 

--- a/lib/rrd_protocol_v2.ml
+++ b/lib/rrd_protocol_v2.ml
@@ -183,11 +183,9 @@ let uninitialised_ds_of_rpc ((name, rpc) : (string * Rpc.t))
 		Rrd_rpc.owner_of_string
 			(Rrd_rpc.assoc_opt ~key:"owner" ~default:"host" kvs) in
 	let default =
-		bool_of_string
-			(Rrd_rpc.assoc_opt ~key:"default"
-				~default:(string_of_bool !Rrd_protocol.ds_default) kvs) in
-	let ds = Ds.ds_make ~name ~description ~units
-		~ty ~value ~min ~max ~default () in
+		bool_of_string (Rrd_rpc.assoc_opt ~key:"default" ~default:"false" kvs) in
+	let ds =
+		Ds.ds_make ~name ~description ~units ~ty ~value ~min ~max ~default () in
 	owner, ds
 
 let parse_metadata metadata =


### PR DESCRIPTION
If a user of this library wants to enable non-default plugins they can do so.
We should not have a mutable variable in this library that they set that tweaks
the datasource's default value. The default value should remain the same even
if the user wants to ignore that and export it anyway.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>