### PR TITLE
CA-253704: Force a memory re-mapping of mapped files with 0 length

### DIFF
--- a/lib/rrd_protocol_v2.ml
+++ b/lib/rrd_protocol_v2.ml
@@ -65,7 +65,7 @@ let get_metadata_start datasource_count =
 module Read = struct
 	let header cs =
 		let header = Bytes.create header_bytes in
-		Cstruct.blit_to_string cs header_start header 0 header_bytes;
+		Cstruct.blit_to_bytes cs header_start header 0 header_bytes;
 		header
 
 	let data_crc cs =
@@ -106,7 +106,7 @@ module Read = struct
 
 	let metadata cs datasource_count metadata_length =
 		let metadata = Bytes.create metadata_length in
-		Cstruct.blit_to_string
+		Cstruct.blit_to_bytes
 			cs (get_metadata_start datasource_count)
 			metadata 0 metadata_length;
 		metadata


### PR DESCRIPTION
There is a race between rrd statistics producers and consumers.
What happens is the following:

- A producer (an rrdd plugin) creates a new file (where it will write the statistics)
- Inotify triggers the registration of the plugin in `xcp-rrdd`
- The following two things can happen in any order:
    - the reader memory maps the new file (that by this time could well be still empty)
    - the producer writes the first statistics on the file

The memory mapped file has a fixed size equal to the size of the file at
the mapping moment, so if we were mapping before the write of the producer
was flushed, we had effectively a null map in memory carrying no content
forever (or until the next toolstack restart): when this happened we
had problems.

The current fix is to check the size of the mapped memory
before reading, if it is zero it forces a remapping of the file.

This does not fix all the issues with the rrdd plugins system but at
leaset brings us back to the old behviour.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>