### PR TITLE
CA-276795: Trim null terminators that can be incorrectly part of the rrd metadata

### DIFF
--- a/lib/rrd_protocol_v2.ml
+++ b/lib/rrd_protocol_v2.ml
@@ -194,7 +194,7 @@ let parse_metadata metadata =
     let datasource_rpcs = Rrd_rpc.dict_of_rpc ~rpc:(List.assoc "datasources" kvs) in
     List.map uninitialised_ds_of_rpc datasource_rpcs
   with exn ->
-    print_endline (Printf.sprintf "Error: %s" (Printexc.to_string exn));
+    Printf.eprintf "Error: %s%!" (Printexc.to_string exn);
     raise Invalid_payload
 
 let make_payload_reader () =


### PR DESCRIPTION
This solves an issue with the new jsonrpc library that does not ignore
the rubbish after the json payload.

This commit also slightly improves the error debugging.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>