### PR TITLE
Update maintainers list and String.{lowercase -> lowercase_ascii}

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,16 +5,7 @@ Please submit changes as pull requests to the repository on github.
 Please ensure that all changes have descriptive commit comments and
 include a Signed-off-by: line.
 
-Maintainers list
+Contact the maintainers
 ----------------
 
-* Christian Lindig <christian.lindig@citrix.com>
-* Euan Harris <euan.harris@citrix.com>
-* Gabor Igloi <gabor.igloi@citrix.com>
-* Jon Ludlam <jonathan.ludlam@citrix.com>
-* Konstantina Chremmou <konstantina.chremmou@citrix.com>
-* Marcello Seri <marcello.seri@citrix.com>
-* Rob Hoes <rob.hoes@citrix.com>
-* Sharad Yadav <sharad.yadav@citrix.com>
-* Zheng Li <zheng.li@citrix.com>
-
+Please direct all queries to `xen-api@lists.xen.org`

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,4 +8,13 @@ include a Signed-off-by: line.
 Maintainers list
 ----------------
 
-* John Else <john.else@citrix.com>
+* Christian Lindig <christian.lindig@citrix.com>
+* Euan Harris <euan.harris@citrix.com>
+* Gabor Igloi <gabor.igloi@citrix.com>
+* Jon Ludlam <jonathan.ludlam@citrix.com>
+* Konstantina Chremmou <konstantina.chremmou@citrix.com>
+* Marcello Seri <marcello.seri@citrix.com>
+* Rob Hoes <rob.hoes@citrix.com>
+* Sharad Yadav <sharad.yadav@citrix.com>
+* Zheng Li <zheng.li@citrix.com>
+

--- a/lib/rrd_protocol_v1.ml
+++ b/lib/rrd_protocol_v1.ml
@@ -29,7 +29,7 @@ type value_type = Float | Int64
 
 (* Converts string to datasource value type. *)
 let val_ty_of_string (s : string) : value_type =
-  match String.lowercase s with
+  match String.lowercase_ascii s with
   | "float" -> Float
   | "int64" -> Int64
   | _ -> raise Invalid_payload

--- a/lib/rrd_rpc.ml
+++ b/lib/rrd_rpc.ml
@@ -30,7 +30,7 @@ let assoc_opt ~(key : string) ~(default : string)
 
 (* Converts string to the corresponding datasource type. *)
 let ds_ty_of_string (s : string) : Rrd.ds_type =
-  match String.lowercase s with
+  match String.lowercase_ascii s with
   | "gauge" -> Rrd.Gauge
   | "absolute" -> Rrd.Absolute
   | "derive" -> Rrd.Derive
@@ -38,7 +38,7 @@ let ds_ty_of_string (s : string) : Rrd.ds_type =
 
 (* Converts a string to value of datasource owner type. *)
 let owner_of_string (s : string) : Rrd.ds_owner =
-  match Astring.String.cuts ~sep:" " (String.lowercase s) with
+  match Astring.String.cuts ~sep:" " (String.lowercase_ascii s) with
   | ["host"] -> Rrd.Host
   | ["vm"; uuid] -> Rrd.VM uuid
   | ["sr"; uuid] -> Rrd.SR uuid

--- a/rrd-transport.opam
+++ b/rrd-transport.opam
@@ -8,7 +8,7 @@ build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "cstruct" {< "3.0.0"}
+  "cstruct"
   "crc"
   "astring"
   "xapi-idl" {>= "1.0.0"}


### PR DESCRIPTION
String.lowercase has been deprecated in favour of String.lowercase_ascii, so this PR seeks to get the compiler to stop yelling at me about that.

Edit: this PR now includes an update to the maintainers list.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>