### PR TITLE
Update maintainers and authors in opam file

### DIFF
--- a/rrd-transport.opam
+++ b/rrd-transport.opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
-maintainer: "john.else@citrix.com"
-authors: "john.else@citrix.com"
+maintainer: "xen-api@lists.xen.org"
+authors: John Else
 homepage: "https://github.com/xapi-project/rrd-transport"
 dev-repo: "https://github.com/xapi-project/rrd-transport"
 bug-reports: "https://github.com/xapi-project/rrd-transport"


### PR DESCRIPTION
Remove John Else's now-defunct email address, change maintainers to point to the xenapi mailing list.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>