### PR TITLE
Update to new xen-gnt-unix and make safe-string compliant

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -22,7 +22,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
               threads
               xcp.rrd
               xen-gnt
-              xen-gnt.unix))
+              xen-gnt-unix))
   %s
  ))
 |} (coverage_rewriter ~full:true)

--- a/lib/rrd_protocol_v2.ml
+++ b/lib/rrd_protocol_v2.ml
@@ -16,9 +16,9 @@ open Crc
 open Rrd_protocol
 
 (* Field sizes. *)
-let default_header = "DATASOURCES"
+let default_header = Bytes.of_string "DATASOURCES"
 
-let header_bytes = String.length default_header
+let header_bytes = Bytes.length default_header
 
 let data_crc_bytes = 4
 
@@ -115,7 +115,7 @@ end
 (* Writing fields to cstructs. *)
 module Write = struct
   let header cs =
-    Cstruct.blit_from_string default_header 0 cs header_start header_bytes
+    Cstruct.blit_from_bytes default_header 0 cs header_start header_bytes
 
   let data_crc cs value =
     Cstruct.BE.set_uint32 cs data_crc_start value
@@ -232,7 +232,10 @@ let make_payload_reader () =
           * datasources, then go back and read the values themselves. *)
          let metadata_length =
            Read.metadata_length cs datasource_count in
-         let metadata = Read.metadata cs datasource_count metadata_length in
+         let metadata =
+           Read.metadata cs datasource_count metadata_length
+           |> Bytes.to_string
+         in
          (* Check the metadata checksum is correct. *)
          if not (metadata_crc = Crc32.string metadata 0 metadata_length)
          then raise Invalid_checksum;

--- a/rrd-transport.opam
+++ b/rrd-transport.opam
@@ -13,6 +13,7 @@ depends: [
   "astring"
   "xapi-idl" {>= "1.0.0"}
   "xapi-rrd" {>= "1.0.0"}
-  "xen-gnt" {< "3.0.0"}
+  "xen-gnt" {>= "3.0.0"}
+  "xen-gnt-unix" {>= "3.0.0"}
   "ounit" {test}
 ]


### PR DESCRIPTION
Required for the xen-gnt-unix update in xs-opam: https://github.com/xapi-project/xs-opam/pull/244
