### PR TITLE
Don't use Bigrarray.Array1.map_file any longer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,12 @@
 language: c
-sudo: false
-services:
-  - docker
-install:
-  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
-script:
-  - bash -ex .travis-docker.sh
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
   global:
-    - OCAML_VERSION=4.07
-    - DISTRO=debian-unstable
-    - PINS="rrd-transport:. xapi-rrd-transport:. xapi-rrd-transport-utils:."
     - PACKAGE=rrd-transport
+    - PINS="rrd-transport:. xapi-rrd-transport:. xapi-rrd-transport-utils:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
   matrix:
-    # We need to pass some Travis environment variables to the container to
-    # enable uploading to coveralls and detection of Travis CI.
-    # Also, set TESTS to false to avoid running them twice.
-    - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
-      TEST=false \
-      POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex .coverage.sh"
-    - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
+    - DISTRO="debian-unstable"

--- a/lib/rrd_reader.ml
+++ b/lib/rrd_reader.ml
@@ -38,7 +38,8 @@ module File = struct
     let fd = Unix.openfile path [Unix.O_RDONLY] 0o400 in
     if Unix.lseek fd 0 Unix.SEEK_SET <> 0 then
       failwith "lseek";
-    let mapping = Bigarray.(Array1.map_file fd char c_layout false (-1)) in
+    let mapping = Bigarray.(array1_of_genarray @@ Unix.map_file fd char
+                              c_layout false [|-1|]) in
     Unix.close fd;
     Cstruct.of_bigarray mapping
 

--- a/lib/rrd_writer.ml
+++ b/lib/rrd_writer.ml
@@ -56,7 +56,8 @@ module File = struct
   let init {path; shared_page_count} =
     let size = shared_page_count * page_size in
     let fd = Unix.openfile path [Unix.O_RDWR; Unix.O_CREAT] 0o600 in
-    let mapping = Bigarray.(Array1.map_file fd char c_layout true size) in
+    let mapping = Bigarray.(array1_of_genarray @@ Unix.map_file fd char
+                              c_layout true [|size|]) in
     Unix.close fd;
     let cstruct = Cstruct.of_bigarray mapping in
     path, cstruct


### PR DESCRIPTION
Bigrarray.Array1.map_file is deprecated. Replace it with Unix.map_file
as per the warning message.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>