### PR TITLE
Create separate sub-packages for file and page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,5 @@ env:
     # Also, set TESTS to false to avoid running them twice.
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam \
       TEST=false \
+      OCAML_VERSION="4.07" \
       POST_INSTALL_HOOK="env TRAVIS=$TRAVIS TRAVIS_JOB_ID=$TRAVIS_JOB_ID bash -ex .coverage.sh"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/file/dune
+++ b/file/dune
@@ -8,18 +8,11 @@ let coverage_rewriter =
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
-  (name rrd_transport_lib)
-  (public_name rrd-transport.lib)
+  (name rrd_transport_file)
+  (public_name rrd-transport.file)
   (wrapped false)
   (libraries
-    astring
-    bigarray
-    crc
-    cstruct
-    xapi-rrd
-    threads
-    xapi-idl.rrd
-    ezjsonm
+    rrd_transport_lib
   )
   %s
 )

--- a/file/rrd_file_reader.ml
+++ b/file/rrd_file_reader.ml
@@ -1,0 +1,34 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module File = struct
+  (** Filesystem path. *)
+  type id_t = string
+  type state_t = Cstruct.t
+
+  let init path =
+    let fd = Unix.openfile path [Unix.O_RDONLY] 0o400 in
+    if Unix.lseek fd 0 Unix.SEEK_SET <> 0 then
+      failwith "lseek";
+    let mapping = Bigarray.(array1_of_genarray @@ Unix.map_file fd char
+                              c_layout false [|-1|]) in
+    Unix.close fd;
+    Cstruct.of_bigarray mapping
+
+  let cleanup _ _ = ()
+
+  let expose cstruct = cstruct
+end
+
+include Rrd_reader_functor.Make(File)

--- a/file/rrd_file_writer.ml
+++ b/file/rrd_file_writer.ml
@@ -1,0 +1,54 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type local_id = {
+  path: string;
+  shared_page_count: int;
+}
+
+module File = struct
+  let page_size = 4096
+
+  (** Filesystem path. *)
+  type id_t = local_id
+
+  (** Filesystem path is returned to the caller for future reference. *)
+  type info_t = string
+
+  (** fd for writing to the shared file. *)
+  type state_t = Cstruct.t
+
+  let init {path; shared_page_count} =
+    let size = shared_page_count * page_size in
+    let fd = Unix.openfile path [Unix.O_RDWR; Unix.O_CREAT] 0o600 in
+    let mapping = Bigarray.(array1_of_genarray @@ Unix.map_file fd char
+                              c_layout true [|size|]) in
+    Unix.close fd;
+    let cstruct = Cstruct.of_bigarray mapping in
+    path, cstruct
+
+  let cleanup _ path _ =
+    Unix.unlink path
+
+  (** This assumes there's no limit to the size of file which can be used. *)
+  let get_allocator cstruct =
+    let alloc_cstruct size =
+      if size > Cstruct.len cstruct
+      then failwith "not enough memory";
+      cstruct
+    in
+    alloc_cstruct
+end
+
+include Rrd_writer_functor.Make(File)

--- a/lib/rrd_reader_functor.ml
+++ b/lib/rrd_reader_functor.ml
@@ -1,0 +1,61 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type TRANSPORT = sig
+  (** An identifier needed to open the resource. *)
+  type id_t
+
+  (** A handle to an open resource. *)
+  type state_t
+
+  (** Open a resource for writing, given its identifier. *)
+  val init: id_t -> state_t
+
+  (** Cleanup an open resource when it is no longer needed. *)
+  val cleanup: id_t -> state_t -> unit
+
+  (** Given the state of the open resource, expose its contents as a Cstruct. *)
+  val expose: state_t -> Cstruct.t
+end
+
+type reader = {
+  read_payload: unit -> Rrd_protocol.payload;
+  cleanup: unit -> unit;
+}
+
+module Make (T: TRANSPORT) = struct
+  let create id protocol =
+    let state = ref (T.init id) in
+    let reader = protocol.Rrd_protocol.make_payload_reader () in
+    let is_open = ref true in
+    let read_payload () =
+      if !is_open then begin
+        let cs =
+          if Cstruct.len (T.expose !state) <= 0 
+          then state := (T.init id); 
+          T.expose !state
+        in
+        reader cs
+      end else raise Rrd_io.Resource_closed
+    in
+    let cleanup () =
+      if !is_open then begin
+        T.cleanup id !state;
+        is_open := false
+      end else raise Rrd_io.Resource_closed
+    in {
+      read_payload;
+      cleanup;
+    }
+end

--- a/lib/rrd_reader_functor.mli
+++ b/lib/rrd_reader_functor.mli
@@ -1,0 +1,34 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module type TRANSPORT = sig
+  type id_t
+
+  type state_t
+
+  val init: id_t -> state_t
+
+  val cleanup: id_t -> state_t -> unit
+
+  val expose: state_t -> Cstruct.t
+end
+
+type reader = {
+  read_payload: unit -> Rrd_protocol.payload;
+  cleanup: unit -> unit;
+}
+
+module Make (T: TRANSPORT) : sig
+  val create: T.id_t -> Rrd_protocol.protocol -> reader
+end

--- a/lib/rrd_writer_functor.mli
+++ b/lib/rrd_writer_functor.mli
@@ -26,16 +26,6 @@ module type TRANSPORT = sig
   val get_allocator: state_t -> (int -> Cstruct.t)
 end
 
-type local_id = {
-  path: string;
-  shared_page_count: int;
-}
-
-type interdomain_id = {
-  backend_domid: int;
-  shared_page_count: int;
-}
-
 type writer = {
   write_payload: Rrd_protocol.payload -> unit;
   cleanup: unit -> unit;
@@ -43,12 +33,4 @@ type writer = {
 
 module Make (T: TRANSPORT) : sig
   val create: T.id_t -> Rrd_protocol.protocol -> T.info_t * writer
-end
-
-module FileWriter : sig
-  val create: local_id -> Rrd_protocol.protocol -> string * writer
-end
-
-module PageWriter : sig
-  val create: interdomain_id -> Rrd_protocol.protocol -> int list * writer
 end

--- a/main/dune
+++ b/main/dune
@@ -8,18 +8,12 @@ let coverage_rewriter =
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
-  (name rrd_transport_lib)
-  (public_name rrd-transport.lib)
+  (name rrd_transport)
+  (public_name rrd-transport)
   (wrapped false)
   (libraries
-    astring
-    bigarray
-    crc
-    cstruct
-    xapi-rrd
-    threads
-    xapi-idl.rrd
-    ezjsonm
+    rrd_transport_file
+    rrd_transport_page
   )
   %s
 )

--- a/main/rrd_reader.ml
+++ b/main/rrd_reader.ml
@@ -12,36 +12,13 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module type TRANSPORT = sig
-  type id_t
-
-  type state_t
-
-  val init: id_t -> state_t
-
-  val cleanup: id_t -> state_t -> unit
-
-  val expose: state_t -> Cstruct.t
-end
-
-type interdomain_id = {
-  frontend_domid: int;
-  shared_page_refs: int list;
-}
-
-type reader = {
+type reader = Rrd_reader_functor.reader = {
   read_payload: unit -> Rrd_protocol.payload;
   cleanup: unit -> unit;
 }
 
-module Make (T: TRANSPORT) : sig
-  val create: T.id_t -> Rrd_protocol.protocol -> reader
-end
+include Rrd_file_reader
+include Rrd_page_reader
 
-module FileReader : sig
-  val create: string -> Rrd_protocol.protocol -> reader
-end
-
-module PageReader : sig
-  val create: interdomain_id -> Rrd_protocol.protocol -> reader
-end
+module FileReader = Rrd_file_reader
+module PageReader = Rrd_page_reader

--- a/main/rrd_writer.ml
+++ b/main/rrd_writer.ml
@@ -1,0 +1,24 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type writer = Rrd_writer_functor.writer = {
+  write_payload: Rrd_protocol.payload -> unit;
+  cleanup: unit -> unit;
+}
+
+include Rrd_file_writer
+include Rrd_page_writer
+
+module FileWriter = Rrd_file_writer
+module PageWriter = Rrd_page_writer

--- a/page/dune
+++ b/page/dune
@@ -8,18 +8,13 @@ let coverage_rewriter =
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
-  (name rrd_transport_lib)
-  (public_name rrd-transport.lib)
+  (name rrd_transport_page)
+  (public_name rrd-transport.page)
   (wrapped false)
   (libraries
-    astring
-    bigarray
-    crc
-    cstruct
-    xapi-rrd
-    threads
-    xapi-idl.rrd
-    ezjsonm
+    rrd_transport_lib
+    xen-gnt
+    xen-gnt-unix
   )
   %s
 )

--- a/page/rrd_page_reader.ml
+++ b/page/rrd_page_reader.ml
@@ -12,42 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-module type TRANSPORT = sig
-  (** An identifier needed to open the resource. *)
-  type id_t
-
-  (** A handle to an open resource. *)
-  type state_t
-
-  (** Open a resource for writing, given its identifier. *)
-  val init: id_t -> state_t
-
-  (** Cleanup an open resource when it is no longer needed. *)
-  val cleanup: id_t -> state_t -> unit
-
-  (** Given the state of the open resource, expose its contents as a Cstruct. *)
-  val expose: state_t -> Cstruct.t
-end
-
-module File = struct
-  (** Filesystem path. *)
-  type id_t = string
-  type state_t = Cstruct.t
-
-  let init path =
-    let fd = Unix.openfile path [Unix.O_RDONLY] 0o400 in
-    if Unix.lseek fd 0 Unix.SEEK_SET <> 0 then
-      failwith "lseek";
-    let mapping = Bigarray.(array1_of_genarray @@ Unix.map_file fd char
-                              c_layout false [|-1|]) in
-    Unix.close fd;
-    Cstruct.of_bigarray mapping
-
-  let cleanup _ _ = ()
-
-  let expose cstruct = cstruct
-end
-
 type interdomain_id = {
   frontend_domid: int;
   shared_page_refs: int list;
@@ -117,36 +81,4 @@ module Page = struct
     Io_page.to_cstruct buf
 end
 
-type reader = {
-  read_payload: unit -> Rrd_protocol.payload;
-  cleanup: unit -> unit;
-}
-
-module Make (T: TRANSPORT) = struct
-  let create id protocol =
-    let state = ref (T.init id) in
-    let reader = protocol.Rrd_protocol.make_payload_reader () in
-    let is_open = ref true in
-    let read_payload () =
-      if !is_open then begin
-        let cs =
-          if Cstruct.len (T.expose !state) <= 0 
-          then state := (T.init id); 
-          T.expose !state
-        in
-        reader cs
-      end else raise Rrd_io.Resource_closed
-    in
-    let cleanup () =
-      if !is_open then begin
-        T.cleanup id !state;
-        is_open := false
-      end else raise Rrd_io.Resource_closed
-    in {
-      read_payload;
-      cleanup;
-    }
-end
-
-module FileReader = Make(File)
-module PageReader = Make(Page)
+include Rrd_reader_functor.Make(Page)

--- a/page/rrd_page_writer.ml
+++ b/page/rrd_page_writer.ml
@@ -1,0 +1,54 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+type interdomain_id = {
+  backend_domid: int;
+  shared_page_count: int;
+}
+
+module Page = struct
+  open Gnt
+
+  type id_t = interdomain_id
+
+  (** list of shared pages *)
+  type info_t = int list
+  type state_t = Gntshr.share
+
+  let init {backend_domid; shared_page_count} =
+    let share =
+      Gntshr.with_gntshr
+        (fun gntshr ->
+           Gntshr.share_pages_exn gntshr backend_domid shared_page_count false)
+    in
+    share.Gntshr.refs, share
+
+  let cleanup _ _ share =
+    Gntshr.with_gntshr
+      (fun gntshr -> Gntshr.munmap_exn gntshr share)
+
+  (** The allocator returns a Cstruct mapping all of the shared memory, unless
+      	 *  the size requested is greater than the size of this memory in which case
+      	 *  the allocator fails. *)
+  let get_allocator share =
+    let alloc_cstruct size =
+      let c = Io_page.to_cstruct share.Gntshr.mapping in
+      if size > Cstruct.len c then
+        failwith "not enough memory";
+      c
+    in
+    alloc_cstruct
+end
+
+include Rrd_writer_functor.Make(Page)


### PR DESCRIPTION
The top-level module that covers both the file and page mechanism still exists,
but it is now possible to link to just the file-based transport, which avoids
linking against xen libraries.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>